### PR TITLE
[BUGFIX] Avoid error in detail view of order plugin

### DIFF
--- a/Classes/Controller/Order/OrderController.php
+++ b/Classes/Controller/Order/OrderController.php
@@ -90,8 +90,8 @@ class OrderController extends ActionController
         $paymentStatusOptions = [];
         $items = $GLOBALS['TCA']['tx_cart_domain_model_order_payment']['columns']['status']['config']['items'];
         foreach ($items as $item) {
-            $paymentStatusOptions[$item[1]] = LocalizationUtility::translate(
-                $item[0],
+            $paymentStatusOptions[$item['value']] = LocalizationUtility::translate(
+                $item['label'],
                 'Cart'
             );
         }
@@ -100,8 +100,8 @@ class OrderController extends ActionController
         $shippingStatusOptions = [];
         $items = $GLOBALS['TCA']['tx_cart_domain_model_order_shipping']['columns']['status']['config']['items'];
         foreach ($items as $item) {
-            $shippingStatusOptions[$item[1]] = LocalizationUtility::translate(
-                $item[0],
+            $shippingStatusOptions[$item['value']] = LocalizationUtility::translate(
+                $item['label'],
                 'Cart'
             );
         }


### PR DESCRIPTION
The plugin throw an error because the the
controller tried to access an array by
integer index values instead of strings.