### PR TITLE
[TASK] Check stock during order process

### DIFF
--- a/Classes/Controller/Cart/ProductController.php
+++ b/Classes/Controller/Cart/ProductController.php
@@ -130,7 +130,7 @@ class ProductController extends ActionController
                 'count' => $this->cart->getCount(),
                 'net' => $this->cart->getNet(),
                 'gross' => $this->cart->getGross(),
-                'productsChanged' => $productsChanged,
+                'productsChangeStarterkitd' => $productsChanged,
                 'messageBody' => $messageBody,
                 'messageTitle' => $messageTitle,
                 'severity' => $severity,

--- a/Classes/Event/ProcessOrderCheckStockEvent.php
+++ b/Classes/Event/ProcessOrderCheckStockEvent.php
@@ -12,9 +12,12 @@ namespace Extcode\Cart\Event;
  */
 
 use Extcode\Cart\Domain\Model\Cart\Cart;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
 
 final class ProcessOrderCheckStockEvent implements ProcessOrderCheckStockEventInterface
 {
+    private bool $allProductsAvailable = true;
+
     public function __construct(
         private readonly Cart $cart
     ) {}
@@ -22,5 +25,39 @@ final class ProcessOrderCheckStockEvent implements ProcessOrderCheckStockEventIn
     public function getCart(): Cart
     {
         return $this->cart;
+    }
+
+    public function allProductsAreAvailable(): bool
+    {
+        return $this->allProductsAvailable;
+    }
+
+    public function setNotAllProductsAreAvailable(): void
+    {
+        $this->allProductsAvailable = false;
+    }
+
+    /**
+     * @return FlashMessage[]
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * @param FlashMessage[] $messages
+     */
+    public function setMessages(array $messages): void
+    {
+        $this->messages = $messages;
+    }
+
+    /**
+     * @param FlashMessage $message
+     */
+    public function addMessage(FlashMessage $message): void
+    {
+        $this->messages[] = $message;
     }
 }

--- a/Classes/Event/ProcessOrderCheckStockEventInterface.php
+++ b/Classes/Event/ProcessOrderCheckStockEventInterface.php
@@ -18,4 +18,11 @@ interface ProcessOrderCheckStockEventInterface
     public function __construct(Cart $cart);
 
     public function getCart(): Cart;
+
+    public function allProductsAreAvailable(): bool;
+
+    /**
+     * @return FlashMessage[]
+     */
+    public function getMessages(): array;
 }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -10,6 +10,9 @@
             <trans-unit id="tx_cart.error.stock_handling.update">
                 <source>Desired number of this item not available.</source>
             </trans-unit>
+            <trans-unit id="tx_cart.error.stock_handling.order">
+                <source>The product "%s" with the SKU "%s" is not available in the desired amount. The current stock of this product is %s. Caution: The stock is not reserved for you.'</source>
+            </trans-unit>
             <trans-unit id="tx_cart.success.stock_handling.add.one">
                 <source>Item was added to cart.</source>
             </trans-unit>


### PR DESCRIPTION
Extend the event `ProcessOrderCheckStockEvent`
so that EventListeners can set the availability.

Fixes https://github.com/extcode/cart/issues/309