### PR TITLE
[BUGFIX] Customer always gets correct shipping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         working-directory: ./Build/Sources
 
       - name: Run ESLint
-        run: npm run build
+        run: npm run lint
         working-directory: ./Build/Sources
 
   coding-guideline:

--- a/Build/Sources/JavaScript/update_country.js
+++ b/Build/Sources/JavaScript/update_country.js
@@ -18,8 +18,8 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   /**
-     * Listen to changes of cart form field for billing country.
-     */
+   * Listen to changes of cart form field for billing country.
+   */
   billingCountryElement.addEventListener('change', () => {
     const billingCountry = billingCountryElement.value;
     let shippingCountry = '';
@@ -31,8 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   /**
-     * Listen to changes of cart form field for shipping country.
-     */
+   * Listen to changes of cart form field for shipping country.
+   */
   shippingCountryElement.addEventListener('change', () => {
     const billingCountry = billingCountryElement.value;
     const shippingCountry = shippingCountryElement.value;
@@ -41,9 +41,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   /**
-     * Listen to changes of cart form field whether shipping address is same as billing address.
-     */
-  shippingSameAsBillingElement.addEventListener('change', () => {
+   * Listen to changes of cart form field whether shipping address is same as billing address.
+   */
+  shippingSameAsBillingElement.addEventListener('change', function () {
     const stepShippingAddressElement = document.querySelector('#checkout-step-shipping-address');
     if (shippingSameAsBillingElement.checked) {
       stepShippingAddressElement.style.display = 'none';
@@ -52,7 +52,12 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const billingCountry = billingCountryElement.value;
-    const shippingCountry = shippingCountryElement.value;
+    // Shipping costs shall depend on billing country if shipping address == billing address.
+    // Due to this the value of the shipping country is only considered if the shipping address
+    // differs from the billing address.
+    const shippingCountry = shippingSameAsBillingElement.checked
+      ? billingCountryElement.value
+      : shippingCountryElement.value;
 
     // Disable shipping fields if shipping address == billing address.
     const disabledStatus = shippingSameAsBillingElement.checked;

--- a/Resources/Private/Partials/Cart/OrderForm/Address/Shipping.html
+++ b/Resources/Private/Partials/Cart/OrderForm/Address/Shipping.html
@@ -12,7 +12,7 @@
                              id="shipping-same-as-billing"
                              value="1"
                              title="{f:translate(key:'tx_cart.same_address')}"
-                             checked="{f:if(condition:'{cart.shippingSameAsBilling}')}"/>
+                             checked="{f:if(condition:'{cart.shippingSameAsBilling}', then: 'true', else: 'false')}"/>
             <span><f:translate key="tx_cart.same_address"/></span>
         </label>
     </div>

--- a/Resources/Public/JavaScript/update_country.js
+++ b/Resources/Public/JavaScript/update_country.js
@@ -54,7 +54,7 @@
       const shippingCountry = shippingCountryElement.value;
       updateCountry(billingCountry, shippingCountry);
     });
-    shippingSameAsBillingElement.addEventListener("change", () => {
+    shippingSameAsBillingElement.addEventListener("change", function() {
       const stepShippingAddressElement = document.querySelector("#checkout-step-shipping-address");
       if (shippingSameAsBillingElement.checked) {
         stepShippingAddressElement.style.display = "none";
@@ -62,7 +62,7 @@
         stepShippingAddressElement.style.display = null;
       }
       const billingCountry = billingCountryElement.value;
-      const shippingCountry = shippingCountryElement.value;
+      const shippingCountry = shippingSameAsBillingElement.checked ? billingCountryElement.value : shippingCountryElement.value;
       const disabledStatus = shippingSameAsBillingElement.checked;
       setDisabledStatus(stepShippingAddressElement, "input", disabledStatus);
       setDisabledStatus(stepShippingAddressElement, "select", disabledStatus);


### PR DESCRIPTION
If shipping costs differs between two countries
the customer could get wrong shipping costs by
choosing another country in the shipping address
and afterwards checking the checkbox "shipping
is same as billing".

This is fixed by using the billing country for the shipping costs when the customer chooses "shipping is same as billing".

Furthermore the checkbox is always correct checked by augmenting the condition. Before the checkbox was not check on first load but the shipping address
fields were not shown.

Fixes https://github.com/extcode/cart/issues/363