### PR TITLE
[BUGFIX] Use non-breaking space before currency

### DIFF
--- a/Classes/ViewHelpers/Format/CurrencyViewHelper.php
+++ b/Classes/ViewHelpers/Format/CurrencyViewHelper.php
@@ -156,7 +156,7 @@ class CurrencyViewHelper extends AbstractViewHelper
 
         $output = number_format($floatToFormat, $decimals, $decimalSeparator, $thousandsSeparator);
         if (isset($currencySign) && $currencySign !== '') {
-            $currencySeparator = isset($separateCurrency) ? ' ' : '';
+            $currencySeparator = isset($separateCurrency) ? '&nbsp;' : '';
             if (isset($prependCurrency) && $prependCurrency === true) {
                 $output = $currencySign . $currencySeparator . $output;
             } else {


### PR DESCRIPTION
To avoid line breaks the ViewHelper uses a
 non-breaking space to separate the value
 from the currency if spacing is actived.

 Fixes #489